### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-uri_decoder
+# fluent-plugin-uri_decoder, a plugin for [Fluentd](http://fluentd.org)
 
 Fluent plugin to decode uri encoded value.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
