### PR TITLE
Update out_uri_decode.rb

### DIFF
--- a/lib/fluent/plugin/out_uri_decode.rb
+++ b/lib/fluent/plugin/out_uri_decode.rb
@@ -62,7 +62,7 @@ class Fluent::URIDecoder < Fluent::Output
         record[key_name] = URI.decode(record[key_name] || '')
       end
 
-      Fluent::Engine.emit(tag, time, record)
+      router.emit(tag, time, record)
     end
 
     chain.next


### PR DESCRIPTION
Because this plugin uses old API.
In v0.12 and v0.14, plugin should use router.emit, not Engine.emit.

Official announce:http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released